### PR TITLE
Add User CRUD with validation and AutoMapper integration

### DIFF
--- a/PraktikPortalen.Application/DTOs/Users/UserCreateDto.cs
+++ b/PraktikPortalen.Application/DTOs/Users/UserCreateDto.cs
@@ -1,0 +1,11 @@
+﻿namespace PraktikPortalen.Application.DTOs.Users
+{
+    public sealed class UserCreateDto
+    {
+        public string Email { get; set; } = default!;
+        public string Password { get; set; } = default!;
+        public string FullName { get; set; } = default!;
+        public int Role { get; set; } = 0;
+        public bool IsActive { get; set; } = true;
+    }
+}

--- a/PraktikPortalen.Application/DTOs/Users/UserDetailDto.cs
+++ b/PraktikPortalen.Application/DTOs/Users/UserDetailDto.cs
@@ -1,0 +1,12 @@
+﻿namespace PraktikPortalen.Application.DTOs.Users
+{
+    public sealed class UserDetailDto
+    {
+        public int Id { get; set; }
+        public string Email { get; set; } = default!;
+        public string FullName { get; set; } = default!;
+        public string Role { get; set; } = default!;
+        public bool IsActive { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/PraktikPortalen.Application/DTOs/Users/UserListDto.cs
+++ b/PraktikPortalen.Application/DTOs/Users/UserListDto.cs
@@ -1,0 +1,11 @@
+﻿namespace PraktikPortalen.Application.DTOs.Users
+{
+    public sealed class UserListDto
+    {
+        public int Id { get; set; }
+        public string Email { get; set; } = default!;
+        public string FullName { get; set; } = default!;
+        public string Role { get; set; } = default!;
+        public bool IsActive { get; set; }
+    }
+}

--- a/PraktikPortalen.Application/DTOs/Users/UserUpdateDto.cs
+++ b/PraktikPortalen.Application/DTOs/Users/UserUpdateDto.cs
@@ -1,0 +1,9 @@
+﻿namespace PraktikPortalen.Application.DTOs.Users
+{
+    public sealed class UserUpdateDto
+    {
+        public string FullName { get; set; } = default!;
+        public int Role { get; set; }
+        public bool IsActive { get; set; }
+    }
+}

--- a/PraktikPortalen.Application/Mapping/MappingProfile.cs
+++ b/PraktikPortalen.Application/Mapping/MappingProfile.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using PraktikPortalen.Application.DTOs.Companies;
 using PraktikPortalen.Application.DTOs.Internships;
+using PraktikPortalen.Application.DTOs.Users;
 using PraktikPortalen.Domain.Entities;
 
 namespace PraktikPortalen.Application.Mapping
@@ -9,6 +10,7 @@ namespace PraktikPortalen.Application.Mapping
     {
         public MappingProfile()
         {
+            // ------- Internship mappings -------
             CreateMap<Internship, InternshipListDto>()
                 .ForMember(d => d.CompanyName, m => m.MapFrom(s => s.Company.Name))
                 .ForMember(d => d.CategoryName, m => m.MapFrom(s => s.Category.Name));
@@ -21,10 +23,23 @@ namespace PraktikPortalen.Application.Mapping
             CreateMap<InternshipCreateDto, Internship>();
             CreateMap<InternshipUpdateDto, Internship>();
 
+            // ------- Company mappings -------
             CreateMap<Company, CompanyListDto>();
             CreateMap<Company, CompanyDetailDto>();
             CreateMap<CompanyCreateDto, Company>();
             CreateMap<CompanyUpdateDto, Company>();
+
+            // ------- User mappings -------
+            CreateMap<User, UserListDto>()
+            .ForMember(d => d.Role, m => m.MapFrom(s => s.Role.ToString()));
+
+            CreateMap<User, UserDetailDto>()
+                .ForMember(d => d.Role, m => m.MapFrom(s => s.Role.ToString()));
+
+            CreateMap<UserCreateDto, User>()
+                .ForMember(d => d.PasswordHash, m => m.Ignore()); // password handled separately
+
+            CreateMap<UserUpdateDto, User>();
         }
     }
 }

--- a/PraktikPortalen.Application/Services/Interfaces/IUserService.cs
+++ b/PraktikPortalen.Application/Services/Interfaces/IUserService.cs
@@ -1,0 +1,13 @@
+﻿using PraktikPortalen.Application.DTOs.Users;
+
+namespace PraktikPortalen.Application.Services.Interfaces
+{
+    public interface IUserService
+    {
+        Task<List<UserListDto>> GetAllAsync(CancellationToken ct = default);
+        Task<UserDetailDto?> GetByIdAsync(int id, CancellationToken ct = default);
+        Task<int> CreateAsync(UserCreateDto dto, CancellationToken ct = default);
+        Task<bool> UpdateAsync(int id, UserUpdateDto dto, CancellationToken ct = default);
+        Task<bool> DeleteAsync(int id, CancellationToken ct = default);
+    }
+}

--- a/PraktikPortalen.Application/Services/UserService.cs
+++ b/PraktikPortalen.Application/Services/UserService.cs
@@ -1,0 +1,69 @@
+﻿using AutoMapper;
+using Microsoft.AspNetCore.Identity;
+using PraktikPortalen.Application.DTOs.Users;
+using PraktikPortalen.Application.Services.Interfaces;
+using PraktikPortalen.Domain.Entities;
+using PraktikPortalen.Domain.Interfaces.Repositories;
+
+namespace PraktikPortalen.Application.Services
+{
+    public class UserService : IUserService
+    {
+        private readonly IUserRepository _repo;
+        private readonly IPasswordHasher<User> _hasher;
+        private readonly IMapper _mapper;
+
+        public UserService(IUserRepository repo, IPasswordHasher<User> hasher, IMapper mapper)
+        {
+            _repo = repo;
+            _hasher = hasher;
+            _mapper = mapper;
+        }
+
+        public async Task<List<UserListDto>> GetAllAsync(CancellationToken ct = default)
+        {
+            var users = await _repo.GetAllAsync(ct);
+            return _mapper.Map<List<UserListDto>>(users);
+        }
+
+        public async Task<UserDetailDto?> GetByIdAsync(int id, CancellationToken ct = default)
+        {
+            var user = await _repo.GetByIdAsync(id, ct);
+            return user is null ? null : _mapper.Map<UserDetailDto>(user);
+        }
+
+        public async Task<int> CreateAsync(UserCreateDto dto, CancellationToken ct = default)
+        {
+            // Map input → entity (PasswordHash ignored by profile)
+            var entity = _mapper.Map<User>(dto);
+
+            // Hash the incoming password
+            entity.PasswordHash = _hasher.HashPassword(entity, dto.Password);
+
+            await _repo.AddAsync(entity, ct);
+            await _repo.SaveChangesAsync(ct);
+            return entity.Id;
+        }
+
+        public async Task<bool> UpdateAsync(int id, UserUpdateDto dto, CancellationToken ct = default)
+        {
+            var entity = await _repo.GetByIdAsync(id, ct);
+            if (entity is null) return false;
+
+            // Map onto the tracked entity (updates FullName/Role/IsActive)
+            _mapper.Map(dto, entity);
+
+            await _repo.UpdateAsync(entity, ct);
+            return await _repo.SaveChangesAsync(ct);
+        }
+
+        public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
+        {
+            var entity = await _repo.GetByIdAsync(id, ct);
+            if (entity is null) return false;
+
+            await _repo.DeleteAsync(entity, ct);
+            return await _repo.SaveChangesAsync(ct);
+        }
+    }
+}

--- a/PraktikPortalen.Application/Validation/Users/UserCreateDtoValidator.cs
+++ b/PraktikPortalen.Application/Validation/Users/UserCreateDtoValidator.cs
@@ -1,0 +1,31 @@
+﻿using FluentValidation;
+using PraktikPortalen.Application.DTOs.Users;
+
+namespace PraktikPortalen.Application.Validation.Users
+{
+    public class UserCreateDtoValidator : AbstractValidator<UserCreateDto>
+    {
+        public UserCreateDtoValidator()
+        {
+            RuleFor(x => x.Email)
+                .NotEmpty().WithMessage("Email is required.")
+                .EmailAddress().WithMessage("A valid email address is required.");
+
+            RuleFor(x => x.Password)
+                .NotEmpty().WithMessage("Password is required.")
+                .MinimumLength(6).WithMessage("Password must be at least 6 characters long.")
+                .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter.")
+                .Matches("[a-z]").WithMessage("Password must contain at least one lowercase letter.")
+                .Matches("[0-9]").WithMessage("Password must contain at least one number.")
+                .Matches("[^a-zA-Z0-9]").WithMessage("Password must contain at least one special character.");
+
+            RuleFor(x => x.FullName)
+                .NotEmpty().WithMessage("Full name is required.")
+                .MaximumLength(128);
+
+            RuleFor(x => x.Role)
+                .GreaterThanOrEqualTo(0).WithMessage("Invalid role.");
+
+        }
+    }
+}

--- a/PraktikPortalen.Application/Validation/Users/UserUpdateDtoValidator.cs
+++ b/PraktikPortalen.Application/Validation/Users/UserUpdateDtoValidator.cs
@@ -1,0 +1,18 @@
+﻿using FluentValidation;
+using PraktikPortalen.Application.DTOs.Users;
+
+namespace PraktikPortalen.Application.Validation.Users
+{
+    public class UserUpdateDtoValidator : AbstractValidator<UserUpdateDto>
+    {
+        public UserUpdateDtoValidator()
+        {
+            RuleFor(x => x.FullName)
+                .NotEmpty().WithMessage("Full name is required.")
+                .MaximumLength(128);
+
+            RuleFor(x => x.Role)
+                .GreaterThanOrEqualTo(0).WithMessage("Invalid role.");
+        }
+    }
+}

--- a/PraktikPortalen.Domain/Interfaces/Repositories/IUserRepository.cs
+++ b/PraktikPortalen.Domain/Interfaces/Repositories/IUserRepository.cs
@@ -4,8 +4,12 @@ namespace PraktikPortalen.Domain.Interfaces.Repositories
 {
     public interface IUserRepository
     {
+        Task<List<User>> GetAllAsync(CancellationToken ct = default);
+        Task<User?> GetByIdAsync(int id, CancellationToken ct = default);
         Task<User?> GetByEmailAsync(string email, CancellationToken ct = default);
         Task AddAsync(User user, CancellationToken ct = default);
+        Task UpdateAsync(User entity, CancellationToken ct = default);
+        Task DeleteAsync(User entity, CancellationToken ct = default);
         Task<bool> SaveChangesAsync(CancellationToken ct = default);
     }
 }

--- a/PraktikPortalen.Infrastructure/Repositories/UserRepository.cs
+++ b/PraktikPortalen.Infrastructure/Repositories/UserRepository.cs
@@ -10,12 +10,33 @@ namespace PraktikPortalen.Infrastructure.Repositories
         private readonly PraktikportalenDbContext _db;
         public UserRepository(PraktikportalenDbContext db) => _db = db;
 
+        public Task<List<User>> GetAllAsync(CancellationToken ct = default) =>
+            _db.Users.AsNoTracking()
+                .OrderBy(u => u.FullName)
+                .ToListAsync(ct);
+
+        public Task<User?> GetByIdAsync(int id, CancellationToken ct = default) =>
+            _db.Users.AsNoTracking()
+                .FirstOrDefaultAsync(u => u.Id == id, ct);
+
         public Task<User?> GetByEmailAsync(string email, CancellationToken ct = default) =>
             _db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Email == email, ct);
 
         public async Task AddAsync(User user, CancellationToken ct = default)
         {
             await _db.Users.AddAsync(user, ct);
+        }
+
+        public Task UpdateAsync(User entity, CancellationToken ct = default)
+        {
+            _db.Users.Update(entity);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteAsync(User entity, CancellationToken ct = default)
+        {
+            _db.Users.Remove(entity);
+            return Task.CompletedTask;
         }
 
         public async Task<bool> SaveChangesAsync(CancellationToken ct = default) =>

--- a/PraktikPortalen/Api/Controllers/UsersController.cs
+++ b/PraktikPortalen/Api/Controllers/UsersController.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PraktikPortalen.Application.DTOs.Users;
+using PraktikPortalen.Application.Services.Interfaces;
+
+namespace PraktikPortalen.Controllers
+{
+    [ApiController]
+    [Route("api/v1/users")]
+    [Authorize(Roles = "Admin")]
+    public class UsersController : ControllerBase
+    {
+        private readonly IUserService _service;
+        public UsersController(IUserService service) => _service = service;
+
+        [HttpGet("all")]
+        public async Task<IActionResult> GetAll(CancellationToken ct) =>
+            Ok(await _service.GetAllAsync(ct));
+
+        [HttpGet("{id:int}/details")]
+        public async Task<IActionResult> GetById(int id, CancellationToken ct)
+        {
+            var dto = await _service.GetByIdAsync(id, ct);
+            return dto is null ? NotFound() : Ok(dto);
+        }
+
+        [HttpPost("create")]
+        public async Task<IActionResult> Create([FromBody] UserCreateDto dto, CancellationToken ct)
+        {
+            if (!ModelState.IsValid) return ValidationProblem(ModelState);
+            var id = await _service.CreateAsync(dto, ct);
+            return CreatedAtAction(nameof(GetById), new { id }, null);
+        }
+
+        [HttpPut("{id:int}/update")]
+        public async Task<IActionResult> Update(int id, [FromBody] UserUpdateDto dto, CancellationToken ct)
+        {
+            if (!ModelState.IsValid) return ValidationProblem(ModelState);
+            var ok = await _service.UpdateAsync(id, dto, ct);
+            return ok ? NoContent() : NotFound();
+        }
+
+        [HttpDelete("{id:int}/delete")]
+        public async Task<IActionResult> Delete(int id, CancellationToken ct)
+        {
+            var ok = await _service.DeleteAsync(id, ct);
+            return ok ? NoContent() : NotFound();
+        }
+    }
+}

--- a/PraktikPortalen/Program.cs
+++ b/PraktikPortalen/Program.cs
@@ -35,6 +35,7 @@ namespace PraktikPortalen
             builder.Services.AddScoped<ITokenService, TokenService>();
             builder.Services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();
             builder.Services.AddScoped<ICompanyService, CompanyService>();
+            builder.Services.AddScoped<IUserService, UserService>();
 
             // 3) Infrastructure registrations (repositories, etc.)
             builder.Services.AddInfrastructure();


### PR DESCRIPTION
Add User CRUD with validation and AutoMapper integration

- Updated IUserRepository and UserRepository for full async CRUD
- Added User DTOs (list, detail, create, update)
- Created IUserService and UserService with AutoMapper mapping
- Integrated password hashing in UserService
- Added UsersController with descriptive CRUD endpoints (Admin-only)
- Implemented FluentValidation for UserCreateDto and UserUpdateDto
- Updated MappingProfile with User mappings