### PR TITLE
Add CRUD for Categories

### DIFF
--- a/PraktikPortalen.Application/DTOs/Categories/CategoryCreateDto.cs
+++ b/PraktikPortalen.Application/DTOs/Categories/CategoryCreateDto.cs
@@ -1,0 +1,8 @@
+﻿namespace PraktikPortalen.Application.DTOs.Categories
+{
+    public sealed class CategoryCreateDto
+    {
+        public string Name { get; set; } = default!;
+        public bool IsActive { get; set; } = true;
+    }
+}

--- a/PraktikPortalen.Application/DTOs/Categories/CategoryDetailDto.cs
+++ b/PraktikPortalen.Application/DTOs/Categories/CategoryDetailDto.cs
@@ -1,0 +1,9 @@
+﻿namespace PraktikPortalen.Application.DTOs.Categories
+{
+    public sealed class CategoryDetailDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = default!;
+        public bool IsActive { get; set; }
+    }
+}

--- a/PraktikPortalen.Application/DTOs/Categories/CategoryListDto.cs
+++ b/PraktikPortalen.Application/DTOs/Categories/CategoryListDto.cs
@@ -1,0 +1,7 @@
+﻿namespace PraktikPortalen.Application.DTOs.Categories
+{
+    public sealed class CategoryListDto
+    {
+        public string Name { get; set; } = default!;
+    }
+}

--- a/PraktikPortalen.Application/DTOs/Categories/CategoryUpdateDto.cs
+++ b/PraktikPortalen.Application/DTOs/Categories/CategoryUpdateDto.cs
@@ -1,0 +1,8 @@
+﻿namespace PraktikPortalen.Application.DTOs.Categories
+{
+    public sealed class CategoryUpdateDto
+    {
+        public string Name { get; set; } = default!;
+        public bool IsActive { get; set; }
+    }
+}

--- a/PraktikPortalen.Application/Mapping/MappingProfile.cs
+++ b/PraktikPortalen.Application/Mapping/MappingProfile.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using PraktikPortalen.Application.DTOs.Applications;
+using PraktikPortalen.Application.DTOs.Categories;
 using PraktikPortalen.Application.DTOs.Companies;
 using PraktikPortalen.Application.DTOs.Internships;
 using PraktikPortalen.Application.DTOs.Users;
@@ -60,6 +61,12 @@ namespace PraktikPortalen.Application.Mapping
                 .ForMember(d => d.SubmittedAt, m => m.Ignore());    // set in service
 
             CreateMap<InternshipApplicationUpdateDto, InternshipApplication>(); // maps Status/CoverLetter/CvUrl
+
+            // ------- Category mappings -------
+            CreateMap<Category, CategoryListDto>();
+            CreateMap<Category, CategoryDetailDto>();
+            CreateMap<CategoryCreateDto, Category>();
+            CreateMap<CategoryUpdateDto, Category>();
         }
     }
 }

--- a/PraktikPortalen.Application/Services/CategoryService.cs
+++ b/PraktikPortalen.Application/Services/CategoryService.cs
@@ -1,0 +1,59 @@
+﻿using AutoMapper;
+using PraktikPortalen.Application.DTOs.Categories;
+using PraktikPortalen.Application.Services.Interfaces;
+using PraktikPortalen.Domain.Entities;
+using PraktikPortalen.Domain.Interfaces.Repositories;
+
+namespace PraktikPortalen.Application.Services
+{
+    public class CategoryService : ICategoryService
+    {
+        private readonly ICategoryRepository _repo;
+        private readonly IMapper _mapper;
+
+        public CategoryService(ICategoryRepository repo, IMapper mapper)
+        {
+            _repo = repo;
+            _mapper = mapper;
+        }
+
+        public async Task<List<CategoryListDto>> GetAllAsync(CancellationToken ct = default)
+        {
+            var categories = await _repo.GetAllAsync(ct);
+            return _mapper.Map<List<CategoryListDto>>(categories);
+        }
+
+        public async Task<CategoryDetailDto?> GetByIdAsync(int id, CancellationToken ct = default)
+        {
+            var category = await _repo.GetByIdAsync(id, ct);
+            return category is null ? null : _mapper.Map<CategoryDetailDto>(category);
+        }
+
+        public async Task<int> CreateAsync(CategoryCreateDto dto, CancellationToken ct = default)
+        {
+            var entity = _mapper.Map<Category>(dto);
+            await _repo.AddAsync(entity, ct);
+            await _repo.SaveChangesAsync(ct);
+            return entity.Id;
+        }
+
+        public async Task<bool> UpdateAsync(int id, CategoryUpdateDto dto, CancellationToken ct = default)
+        {
+            var entity = await _repo.GetByIdAsync(id, ct);
+            if (entity is null) return false;
+
+            _mapper.Map(dto, entity);
+            await _repo.UpdateAsync(entity, ct);
+            return await _repo.SaveChangesAsync(ct);
+        }
+
+        public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
+        {
+            var entity = await _repo.GetByIdAsync(id, ct);
+            if (entity is null) return false;
+
+            await _repo.DeleteAsync(entity, ct);
+            return await _repo.SaveChangesAsync(ct);
+        }
+    }
+}

--- a/PraktikPortalen.Application/Services/Interfaces/ICategoryService.cs
+++ b/PraktikPortalen.Application/Services/Interfaces/ICategoryService.cs
@@ -1,0 +1,13 @@
+﻿using PraktikPortalen.Application.DTOs.Categories;
+
+namespace PraktikPortalen.Application.Services.Interfaces
+{
+    public interface ICategoryService
+    {
+        Task<List<CategoryListDto>> GetAllAsync(CancellationToken ct = default);
+        Task<CategoryDetailDto?> GetByIdAsync(int id, CancellationToken ct = default);
+        Task<int> CreateAsync(CategoryCreateDto dto, CancellationToken ct = default);
+        Task<bool> UpdateAsync(int id, CategoryUpdateDto dto, CancellationToken ct = default);
+        Task<bool> DeleteAsync(int id, CancellationToken ct = default);
+    }
+}

--- a/PraktikPortalen.Domain/Interfaces/Repositories/ICategoryRepository.cs
+++ b/PraktikPortalen.Domain/Interfaces/Repositories/ICategoryRepository.cs
@@ -1,0 +1,14 @@
+﻿using PraktikPortalen.Domain.Entities;
+
+namespace PraktikPortalen.Domain.Interfaces.Repositories
+{
+    public interface ICategoryRepository
+    {
+        Task<List<Category>> GetAllAsync(CancellationToken ct = default);
+        Task<Category?> GetByIdAsync(int id, CancellationToken ct = default);
+        Task AddAsync(Category entity, CancellationToken ct = default);
+        Task UpdateAsync(Category entity, CancellationToken ct = default);
+        Task DeleteAsync(Category entity, CancellationToken ct = default);
+        Task<bool> SaveChangesAsync(CancellationToken ct = default);
+    }
+}

--- a/PraktikPortalen.Infrastructure/DependencyInjection.cs
+++ b/PraktikPortalen.Infrastructure/DependencyInjection.cs
@@ -13,6 +13,7 @@ namespace PraktikPortalen.Infrastructure
             services.AddScoped<IInternshipRepository, InternshipRepository>();
             services.AddScoped<ICompanyRepository, CompanyRepository>();
             services.AddScoped<IInternshipApplicationRepository, InternshipApplicationRepository>();
+            services.AddScoped<ICategoryRepository, CategoryRepository>();
             return services;
         }
     }

--- a/PraktikPortalen.Infrastructure/Repositories/CategoryRepository.cs
+++ b/PraktikPortalen.Infrastructure/Repositories/CategoryRepository.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore;
+using PraktikPortalen.Domain.Entities;
+using PraktikPortalen.Domain.Interfaces.Repositories;
+using PraktikPortalen.Infrastructure.Data;
+
+namespace PraktikPortalen.Infrastructure.Repositories
+{
+    public class CategoryRepository : ICategoryRepository
+    {
+        private readonly PraktikportalenDbContext _db;
+        public CategoryRepository(PraktikportalenDbContext db) => _db = db;
+
+        public Task<List<Category>> GetAllAsync(CancellationToken ct = default) =>
+            _db.Categories.AsNoTracking()
+                .OrderBy(c => c.Name)
+                .ToListAsync(ct);
+
+        public Task<Category?> GetByIdAsync(int id, CancellationToken ct = default) =>
+            _db.Categories.FirstOrDefaultAsync(c => c.Id == id, ct);
+
+        public async Task AddAsync(Category entity, CancellationToken ct = default) =>
+            await _db.Categories.AddAsync(entity, ct);
+
+        public Task UpdateAsync(Category entity, CancellationToken ct = default)
+        {
+            _db.Categories.Update(entity);
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteAsync(Category entity, CancellationToken ct = default)
+        {
+            _db.Categories.Remove(entity);
+            return Task.CompletedTask;
+        }
+
+        public async Task<bool> SaveChangesAsync(CancellationToken ct = default) =>
+            await _db.SaveChangesAsync(ct) > 0;
+    }
+}

--- a/PraktikPortalen/Api/Controllers/CategoriesController.cs
+++ b/PraktikPortalen/Api/Controllers/CategoriesController.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PraktikPortalen.Application.DTOs.Categories;
+using PraktikPortalen.Application.Services.Interfaces;
+
+namespace PraktikPortalen.Controllers
+{
+    [ApiController]
+    [Route("api/v1/categories")]
+    public class CategoriesController : ControllerBase
+    {
+        private readonly ICategoryService _service;
+        public CategoriesController(ICategoryService service) => _service = service;
+        
+        [HttpGet("all")]
+        public async Task<IActionResult> GetAll(CancellationToken ct) =>
+            Ok(await _service.GetAllAsync(ct));
+
+        [Authorize(Roles = "Admin")]
+        [HttpGet("{id:int}/details")]
+        public async Task<IActionResult> GetById(int id, CancellationToken ct)
+        {
+            var dto = await _service.GetByIdAsync(id, ct);
+            return dto is null ? NotFound() : Ok(dto);
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpPost("create")]
+        public async Task<IActionResult> Create([FromBody] CategoryCreateDto dto, CancellationToken ct)
+        {
+            if (!ModelState.IsValid) return ValidationProblem(ModelState);
+            var id = await _service.CreateAsync(dto, ct);
+            return CreatedAtAction(nameof(GetById), new { id }, null);
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpPut("{id:int}/update")]
+        public async Task<IActionResult> Update(int id, [FromBody] CategoryUpdateDto dto, CancellationToken ct)
+        {
+            if (!ModelState.IsValid) return ValidationProblem(ModelState);
+            var ok = await _service.UpdateAsync(id, dto, ct);
+            return ok ? NoContent() : NotFound();
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpDelete("{id:int}/delete")]
+        public async Task<IActionResult> Delete(int id, CancellationToken ct)
+        {
+            var ok = await _service.DeleteAsync(id, ct);
+            return ok ? NoContent() : NotFound();
+        }
+    }
+}

--- a/PraktikPortalen/Program.cs
+++ b/PraktikPortalen/Program.cs
@@ -37,6 +37,7 @@ namespace PraktikPortalen
             builder.Services.AddScoped<ICompanyService, CompanyService>();
             builder.Services.AddScoped<IUserService, UserService>();
             builder.Services.AddScoped<IInternshipApplicationService, InternshipApplicationService>();
+            builder.Services.AddScoped<ICategoryService, CategoryService>();
 
             // 3) Infrastructure registrations (repositories, etc.)
             builder.Services.AddInfrastructure();


### PR DESCRIPTION
Add CRUD for Categories

- Added Category DTOs (list, detail, create, update)
- Implemented ICategoryRepository and CategoryRepository
- Added ICategoryService and CategoryService with async CRUD
- Created CategoriesController with endpoints (public list, admin details/create/update/delete)
- Added AutoMapper profiles for Category mappings
- Registered repository in DI