### PR TITLE
Add InternshipCleanupService and updated InternshipApplicationService.CreateAsync

### DIFF
--- a/PraktikPortalen.Infrastructure/DependencyInjection.cs
+++ b/PraktikPortalen.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using PraktikPortalen.Domain.Interfaces.Repositories;
 using PraktikPortalen.Infrastructure.Repositories;
+using PraktikPortalen.Infrastructure.Services;
 
 namespace PraktikPortalen.Infrastructure
 {
@@ -14,6 +15,7 @@ namespace PraktikPortalen.Infrastructure
             services.AddScoped<ICompanyRepository, CompanyRepository>();
             services.AddScoped<IInternshipApplicationRepository, InternshipApplicationRepository>();
             services.AddScoped<ICategoryRepository, CategoryRepository>();
+            services.AddHostedService<InternshipCleanupService>();
             return services;
         }
     }

--- a/PraktikPortalen.Infrastructure/PraktikPortalen.Infrastructure.csproj
+++ b/PraktikPortalen.Infrastructure/PraktikPortalen.Infrastructure.csproj
@@ -12,6 +12,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/PraktikPortalen.Infrastructure/Services/InternshipCleanupService.cs
+++ b/PraktikPortalen.Infrastructure/Services/InternshipCleanupService.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using PraktikPortalen.Infrastructure.Data;
+
+namespace PraktikPortalen.Infrastructure.Services
+{
+    public class InternshipCleanupService : BackgroundService
+    {
+        private readonly IServiceProvider _services;
+        private readonly ILogger<InternshipCleanupService> _logger;
+
+        public InternshipCleanupService(IServiceProvider services, ILogger<InternshipCleanupService> logger)
+        {
+            _services = services;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            // Loop until service is stopped
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _services.CreateScope();
+                    var db = scope.ServiceProvider.GetRequiredService<PraktikportalenDbContext>();
+
+                    var now = DateTime.UtcNow;
+
+                    var expired = await db.Internships
+                        .Where(i => i.IsOpen && i.ApplicationDeadline < now)
+                        .ToListAsync(stoppingToken);
+
+                    if (expired.Any())
+                    {
+                        foreach (var internship in expired)
+                            internship.IsOpen = false;
+
+                        await db.SaveChangesAsync(stoppingToken);
+
+                        _logger.LogInformation(
+                            "Closed {Count} expired internships at {Time}",
+                            expired.Count,
+                            now
+                        );
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error in InternshipCleanupService");
+                }
+
+                // For demo: run every 5 minutes instead of daily
+                await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add InternshipCleanupService and updated InternshipApplicationService.CreateAsync

- Implemented background service (InternshipCleanupService) to automatically close internships past their application deadline
- Registered cleanup worker in Infrastructure DI
- Updated InternshipApplicationService.CreateAsync to enforce business rules:
  * Internship must be open and deadline not passed