### PR TITLE
Add search endpoint for internships with filtering

### DIFF
--- a/PraktikPortalen.Application/Services/Interfaces/IInternshipService.cs
+++ b/PraktikPortalen.Application/Services/Interfaces/IInternshipService.cs
@@ -1,4 +1,5 @@
 ﻿using PraktikPortalen.Application.DTOs.Internships;
+using PraktikPortalen.Domain.Enums;
 
 namespace PraktikPortalen.Application.Services.Interfaces
 {
@@ -9,5 +10,6 @@ namespace PraktikPortalen.Application.Services.Interfaces
         Task<int> CreateAsync(InternshipCreateDto dto, CancellationToken ct = default);
         Task<bool> UpdateAsync(int id, InternshipUpdateDto dto, CancellationToken ct = default);
         Task<bool> DeleteAsync(int id, CancellationToken ct = default);
+        Task<List<InternshipListDto>> GetFilteredAsync(int? categoryId, LocationType? locationType, bool? isOpen, CancellationToken ct = default);
     }
 }

--- a/PraktikPortalen.Application/Services/InternshipService.cs
+++ b/PraktikPortalen.Application/Services/InternshipService.cs
@@ -2,6 +2,7 @@
 using PraktikPortalen.Application.DTOs.Internships;
 using PraktikPortalen.Application.Services.Interfaces;
 using PraktikPortalen.Domain.Entities;
+using PraktikPortalen.Domain.Enums;
 using PraktikPortalen.Domain.Interfaces.Repositories;
 
 namespace PraktikPortalen.Application.Services
@@ -63,6 +64,13 @@ namespace PraktikPortalen.Application.Services
 
             await _repo.DeleteAsync(existing, ct);
             return await _repo.SaveChangesAsync(ct);
+        }
+
+        public async Task<List<InternshipListDto>> GetFilteredAsync(int? categoryId,
+        LocationType? locationType, bool? isOpen, CancellationToken ct = default)
+        {
+            var list = await _repo.GetFilteredAsync(categoryId, locationType, isOpen, ct);
+            return _mapper.Map<List<InternshipListDto>>(list);
         }
     }
 }

--- a/PraktikPortalen.Domain/Enums/LocationType.cs
+++ b/PraktikPortalen.Domain/Enums/LocationType.cs
@@ -1,5 +1,8 @@
-﻿namespace PraktikPortalen.Domain.Enums
+﻿using System.Text.Json.Serialization;
+
+namespace PraktikPortalen.Domain.Enums
 {
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum LocationType
     {
 

--- a/PraktikPortalen.Domain/Interfaces/Repositories/IInternshipRepository.cs
+++ b/PraktikPortalen.Domain/Interfaces/Repositories/IInternshipRepository.cs
@@ -1,4 +1,5 @@
 ﻿using PraktikPortalen.Domain.Entities;
+using PraktikPortalen.Domain.Enums;
 
 namespace PraktikPortalen.Domain.Interfaces.Repositories
 {
@@ -11,5 +12,6 @@ namespace PraktikPortalen.Domain.Interfaces.Repositories
         Task DeleteAsync(Internship entity, CancellationToken ct = default);
         Task<bool> SaveChangesAsync(CancellationToken ct = default);
         Task<bool> ExistsAsync(int id, CancellationToken ct = default);
+        Task<List<Internship>> GetFilteredAsync(int? categoryId, LocationType? locationType, bool? isOpen, CancellationToken ct = default);
     }
 }

--- a/PraktikPortalen.Infrastructure/Repositories/InternshipRepository.cs
+++ b/PraktikPortalen.Infrastructure/Repositories/InternshipRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using PraktikPortalen.Domain.Entities;
+using PraktikPortalen.Domain.Enums;
 using PraktikPortalen.Domain.Interfaces.Repositories;
 using PraktikPortalen.Infrastructure.Data;
 
@@ -50,5 +51,28 @@ namespace PraktikPortalen.Infrastructure.Repositories
 
         public Task<bool> ExistsAsync(int id, CancellationToken ct = default) =>
             _db.Internships.AnyAsync(i => i.Id == id, ct);
+
+        public Task<List<Internship>> GetFilteredAsync(int? categoryId,
+        LocationType? locationType, bool? isOpen,CancellationToken ct = default)
+        {
+            var query = _db.Internships
+                .AsNoTracking()
+                .Include(i => i.Company)
+                .Include(i => i.Category)
+                .AsQueryable();
+
+            if (categoryId.HasValue && categoryId.Value > 0)
+                query = query.Where(i => i.CategoryId == categoryId.Value);
+
+            if (locationType.HasValue)
+                query = query.Where(i => i.LocationType == locationType.Value);
+
+            if (isOpen.HasValue)
+                query = query.Where(i => i.IsOpen == isOpen.Value);
+
+            return query
+                .OrderBy(i => i.ApplicationDeadline)
+                .ToListAsync(ct);
+        }
     }
 }

--- a/PraktikPortalen/Api/Controllers/InternshipsController.cs
+++ b/PraktikPortalen/Api/Controllers/InternshipsController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using PraktikPortalen.Application.DTOs.Internships;
 using PraktikPortalen.Application.Services.Interfaces;
+using PraktikPortalen.Domain.Enums;
 
 namespace PraktikPortalen.Api.Controllers
 {
@@ -48,6 +49,14 @@ namespace PraktikPortalen.Api.Controllers
         {
             var ok = await _service.DeleteAsync(id, ct);
             return ok ? NoContent() : NotFound();
+        }
+
+        [HttpGet("search")]
+        public async Task<IActionResult> Search( [FromQuery] int? categoryId, [FromQuery] LocationType? locationType,
+        [FromQuery] bool? isOpen, CancellationToken ct)
+        {
+            var result = await _service.GetFilteredAsync(categoryId, locationType, isOpen, ct);
+            return Ok(result);
         }
     }
 }


### PR DESCRIPTION
Add search endpoint for internships with filtering

- Implemented GetFilteredAsync in InternshipRepository and InternshipService
- Added controller endpoint /api/v1/internships/search with query params
- Supports filtering by categoryId, locationType, and isOpen (optional combinations)
- Results ordered by ApplicationDeadline and mapped to DTOs